### PR TITLE
Android security 11.0.0 release 71

### DIFF
--- a/src/com/android/launcher3/util/PackageManagerHelper.java
+++ b/src/com/android/launcher3/util/PackageManagerHelper.java
@@ -153,6 +153,18 @@ public class PackageManagerHelper {
      * any permissions
      */
     public boolean hasPermissionForActivity(Intent intent, String srcPackage) {
+        // b/270152142
+        if (Intent.ACTION_CHOOSER.equals(intent.getAction())) {
+            final Bundle extras = intent.getExtras();
+            if (extras == null) {
+                return true;
+            }
+            // If given intent is ACTION_CHOOSER, verify srcPackage has permission over EXTRA_INTENT
+            intent = (Intent) extras.getParcelable(Intent.EXTRA_INTENT);
+            if (intent == null) {
+                return true;
+            }
+        }
         ResolveInfo target = mPm.resolveActivity(intent, 0);
         if (target == null) {
             // Not a valid target


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r71' of https://android.googlesource.com/platform/packages/apps/Launcher3 into arrow-11.0

Android security 11.0.0 release 71
Tag: https://android.googlesource.com/platform/packages/apps/Launcher3/+/refs/tags/android-security-11.0.0_r71

Merge cherrypicks of ['googleplex-android-review.googlesource.com/23526090'] into security-aosp-rvc-release.

Change-Id: [Iad0d6d4325b2372e3e693394937a4f8a2389ccc0](https://android-review.googlesource.com/#/q/Iad0d6d4325b2372e3e693394937a4f8a2389ccc0)