### PR TITLE
Android security 11.0.0 release 74

### DIFF
--- a/src/com/android/launcher3/util/PackageManagerHelper.java
+++ b/src/com/android/launcher3/util/PackageManagerHelper.java
@@ -155,15 +155,8 @@ public class PackageManagerHelper {
     public boolean hasPermissionForActivity(Intent intent, String srcPackage) {
         // b/270152142
         if (Intent.ACTION_CHOOSER.equals(intent.getAction())) {
-            final Bundle extras = intent.getExtras();
-            if (extras == null) {
-                return true;
-            }
-            // If given intent is ACTION_CHOOSER, verify srcPackage has permission over EXTRA_INTENT
-            intent = (Intent) extras.getParcelable(Intent.EXTRA_INTENT);
-            if (intent == null) {
-                return true;
-            }
+            // Chooser shortcuts is not a valid target
+            return false;
         }
         ResolveInfo target = mPm.resolveActivity(intent, 0);
         if (target == null) {


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r74' of https://android.googlesource.com/platform/packages/apps/Launcher3 into arrow-11.0

Android security 11.0.0 release 74
Tag: https://android.googlesource.com/platform/packages/apps/Launcher3/+/refs/tags/android-security-11.0.0_r74

Merge cherrypicks of ['googleplex-android-review.googlesource.com/24751391'] into security-aosp-rvc-release.

Change-Id: [I3da7511622f2241dc7ac5a0e999f674fdfe22d0c](https://android-review.googlesource.com/#/q/I3da7511622f2241dc7ac5a0e999f674fdfe22d0c)